### PR TITLE
Only allow GET and HEAD to use mjpeg proxy endpoints

### DIFF
--- a/pubsub.go
+++ b/pubsub.go
@@ -191,6 +191,11 @@ func clientAddress(r *http.Request) string {
 }
 
 func (pubSub *PubSub) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", fmt.Sprintf("%s, %s", http.MethodGet, http.MethodHead))
+		http.Error(w, "405 Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
 	// prepare response for flushing
 	flusher, ok := w.(http.Flusher)
 	if !ok {


### PR DESCRIPTION
Following up on my previous pull request, this is a simpler way of restricting HTTP methods, while leaving in the option of adding more HTTP methods at some point.