### PR TITLE
Fix issue with "modules on by default" with Go 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/vvidic/mjpeg-proxy


### PR DESCRIPTION
GOPATH will be dropped in the future, which means that we must declare an empty module from now on.
See: https://blog.golang.org/go116-module-changes